### PR TITLE
Fix nav and colors, add placeholder about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>About</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">About</a>
+    <a href="muses.html">Muses</a>
+  </nav>
+  <h1>Tobin</h1>
+  <p>This page is intended to mirror <a href="https://tobin.page/">tobin.page</a>, but the original content could not be retrieved in this offline environment.</p>
+  <img src="" alt="">
+  <video src="" controls></video>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 <body>
   <!-- ─── 顶部导航 ─── -->
   <nav>
-    <a href="about.html"><strong>about</strong></a>
-    <a href="muses.html">muses</a>
+    <a href="index.html"><strong>About</strong></a>
+    <a href="muses.html">Muses</a>
   </nav>
 
   <!-- ─── 两栏布局 ─── -->

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* ─── 基础排版 ─── */
 body{
-  background:#000;
-  color:#fff;
+  background:#fff;
+  color:#000;
   font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,sans-serif;
   max-width:760px;
   margin:0 auto;
@@ -9,7 +9,7 @@ body{
 }
 h1,h2,h3{font-weight:600;line-height:1.3;margin:2.2rem 0 1rem}
 nav{margin-bottom:3rem}
-nav a{margin-right:1.2rem;color:#8ab4ff;text-decoration:none}
+nav a{margin-right:1.2rem;color:#000;text-decoration:none}
 nav a:hover{text-decoration:underline}
 
 /* ─── 无序列表 ─── */


### PR DESCRIPTION
## Summary
- update navigation links so homepage is `About` and second page is `Muses`
- switch site colors to black text on white
- add placeholder `about.html` referencing tobin.page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687198aacb808323b8f6cae2a36a2a0f