### PR TITLE
Fix media coverage alignment

### DIFF
--- a/about.html
+++ b/about.html
@@ -144,13 +144,12 @@
 
  <!-- Media Coverage Section -->
  <div class="flex items-start gap-8 justify-center mb-16">
-   <!-- Media Coverage Title -->
-   <div class="flex-shrink-0" style="width: 192px;">
-     <h2 class="text-2xl font-bold text-black">Media Coverage</h2>
-   </div>
+   <!-- Empty spacer to align with sections above -->
+   <div class="flex-shrink-0" style="width: 192px;"></div>
 
-   <!-- Media Scroll Container -->
+   <!-- Media Coverage Content -->
    <div class="flex-1" style="max-width: 320px; margin-left: 20px;">
+     <h2 class="text-2xl font-bold text-black mb-2">Media Coverage</h2>
      <div id="mediaScroll" class="flex gap-3 overflow-x-auto scroll-container mb-4" style="scroll-behavior: smooth;">
        <!-- Media Item 1 -->
        <div class="media-card flex-shrink-0 cursor-pointer" style="width: 200px;" onclick="window.open('#', '_blank')">


### PR DESCRIPTION
## Summary
- align the "Media Coverage" heading with the about content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68740f07af588323aef6fe0e4ab8f98c