### PR TITLE
Fix movie duplicate and center titles

### DIFF
--- a/muses.html
+++ b/muses.html
@@ -67,6 +67,7 @@ body {
   color: #111827;
   line-height: 1.3;
   margin-bottom: 0.25rem;
+  text-align: center;
 }
 
 .media-author {
@@ -309,10 +310,6 @@ body {
       <div class="media-card">
         <img class="media-image" src="images/muses/movies/Sparrow.png" alt="Sparrow">
         <div class="media-title">Sparrow</div>
-      </div>
-      <div class="media-card">
-        <img class="media-image" src="images/muses/movies/sparrow.png" alt="sparrow">
-        <div class="media-title">sparrow</div>
       </div>
   </div>
 


### PR DESCRIPTION
## Summary
- center book and movie titles on muses page
- remove duplicate listing of *Sparrow*

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68748749eea88323ad59376bbb8b0268